### PR TITLE
Installing make for Ubuntu Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ section for instructions on toolchain installation.
   sudo apt upgrade
   sudo apt install curl
   ```
+- make command
+  
+  Installing make for Ubuntu Linux. (If make is not installed)
+  ```
+  sudo apt install make
+  ```
 - Serial Terminal Emulation Application
 
   There are 2 main purposes for HIMAX WE1 EVB Debug UART port, print application output and burn application to flash by using xmodem send application binary.


### PR DESCRIPTION
For a first time user, a message pops up saying 'make is not installed'.
So, a 'sudo apt install make' commands helps avoiding the error for first timers.
![image](https://user-images.githubusercontent.com/87312836/126817590-75cf31c6-533e-422c-971b-7be3c8599270.png)
 